### PR TITLE
R2B-50-AuthHandling

### DIFF
--- a/app/components/login/LoginRedirectModal.tsx
+++ b/app/components/login/LoginRedirectModal.tsx
@@ -1,4 +1,3 @@
-// src/components/common/LoginRedirectModal.tsx
 'use client';
 import { useEffect } from 'react';
 import { X } from 'lucide-react';

--- a/app/components/login/LoginRedirectModal.tsx
+++ b/app/components/login/LoginRedirectModal.tsx
@@ -1,0 +1,90 @@
+'use client';
+import { useEffect } from 'react';
+import { X } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+
+import { useLoginRedirectModalStore } from '@/stores/useLoginRedirectModalStore';
+
+export default function LoginRedirectModal() {
+  const { open, closeModal } = useLoginRedirectModalStore();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        closeModal();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [open, closeModal]);
+
+  if (!open) return null;
+
+  const handleConfirm = () => {
+    closeModal();
+    router.push('/login');
+  };
+
+  return (
+    <div
+      className='fixed inset-0 flex items-center justify-center z-50 bg-gradient-to-br from-[#a86629cc] to-[#714326cc] backdrop-blur-sm'
+      onClick={closeModal}
+    >
+      <div
+        className='
+          relative
+          bg-white/20
+          backdrop-blur-2xl
+          rounded-2xl
+          shadow-2xl
+          p-7
+          w-full
+          max-w-xs
+          border
+          border-white/30
+          flex flex-col
+          items-center
+        '
+        style={{
+          boxShadow: '0 4px 32px 0 rgba(48, 27, 1, 0.15)',
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* 닫기(X) 버튼 */}
+        <button
+          onClick={closeModal}
+          className='absolute top-5 right-5 text-white/80 hover:text-white transition'
+        >
+          <X size={22} />
+        </button>
+        <h2 className='text-white text-base font-semibold mb-2 text-center'>
+          로그인이 필요합니다
+        </h2>
+        <p className='text-sm mb-6 text-white/80 text-center'>
+          로그인 페이지로 이동하시겠습니까?
+        </p>
+        <div className='flex gap-2 w-full justify-center'>
+          <button
+            className='
+              px-4 py-2 rounded-xl 
+              bg-white/40 
+              hover:bg-white/60 
+              text-white
+              font-semibold 
+              transition 
+              border border-white/60
+              shadow
+            '
+            onClick={handleConfirm}
+          >
+            로그인하러 가기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/components/login/LoginRedirectModal.tsx
+++ b/app/components/login/LoginRedirectModal.tsx
@@ -1,3 +1,4 @@
+// src/components/common/LoginRedirectModal.tsx
 'use client';
 import { useEffect } from 'react';
 import { X } from 'lucide-react';
@@ -5,19 +6,17 @@ import { useRouter } from 'next/navigation';
 
 import { useLoginRedirectModalStore } from '@/stores/useLoginRedirectModalStore';
 
+import Portal from './Portal';
+
 export default function LoginRedirectModal() {
   const { open, closeModal } = useLoginRedirectModalStore();
   const router = useRouter();
 
   useEffect(() => {
     if (!open) return;
-
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        closeModal();
-      }
+      if (e.key === 'Escape') closeModal();
     };
-
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [open, closeModal]);
@@ -30,61 +29,63 @@ export default function LoginRedirectModal() {
   };
 
   return (
-    <div
-      className='fixed inset-0 flex items-center justify-center z-50 bg-gradient-to-br from-[#a86629cc] to-[#714326cc] backdrop-blur-sm'
-      onClick={closeModal}
-    >
+    <Portal>
       <div
-        className='
-          relative
-          bg-white/20
-          backdrop-blur-2xl
-          rounded-2xl
-          shadow-2xl
-          p-7
-          w-full
-          max-w-xs
-          border
-          border-white/30
-          flex flex-col
-          items-center
-        '
-        style={{
-          boxShadow: '0 4px 32px 0 rgba(48, 27, 1, 0.15)',
-        }}
-        onClick={(e) => e.stopPropagation()}
+        className='fixed inset-0 flex items-center justify-center z-50 bg-gradient-to-br from-[#a86629cc] to-[#714326cc] backdrop-blur-sm'
+        onClick={closeModal}
       >
-        {/* 닫기(X) 버튼 */}
-        <button
-          onClick={closeModal}
-          className='absolute top-5 right-5 text-white/80 hover:text-white transition'
+        <div
+          className='
+            relative
+            bg-white/20
+            backdrop-blur-2xl
+            rounded-2xl
+            shadow-2xl
+            p-7
+            w-full
+            max-w-xs
+            border
+            border-white/30
+            flex flex-col
+            items-center
+          '
+          style={{
+            boxShadow: '0 4px 32px 0 rgba(48, 27, 1, 0.15)',
+          }}
+          onClick={(e) => e.stopPropagation()}
         >
-          <X size={22} />
-        </button>
-        <h2 className='text-white text-base font-semibold mb-2 text-center'>
-          로그인이 필요합니다
-        </h2>
-        <p className='text-sm mb-6 text-white/80 text-center'>
-          로그인 페이지로 이동하시겠습니까?
-        </p>
-        <div className='flex gap-2 w-full justify-center'>
+          {/* 닫기(X) 버튼 */}
           <button
-            className='
-              px-4 py-2 rounded-xl 
-              bg-white/40 
-              hover:bg-white/60 
-              text-white
-              font-semibold 
-              transition 
-              border border-white/60
-              shadow
-            '
-            onClick={handleConfirm}
+            onClick={closeModal}
+            className='absolute top-5 right-5 text-white/80 hover:text-white transition'
           >
-            로그인하러 가기
+            <X size={22} />
           </button>
+          <h2 className='text-white text-base font-semibold mb-2 text-center'>
+            로그인이 필요합니다
+          </h2>
+          <p className='text-sm mb-6 text-white/80 text-center'>
+            로그인 페이지로 이동하시겠습니까?
+          </p>
+          <div className='flex gap-2 w-full justify-center'>
+            <button
+              className='
+                px-4 py-2 rounded-xl 
+                bg-white/40 
+                hover:bg-white/60 
+                text-white
+                font-semibold 
+                transition 
+                border border-white/60
+                shadow
+              '
+              onClick={handleConfirm}
+            >
+              로그인하러 가기
+            </button>
+          </div>
         </div>
       </div>
-    </div>
+    </Portal>
   );
 }

--- a/app/components/login/Portal.tsx
+++ b/app/components/login/Portal.tsx
@@ -1,4 +1,3 @@
-// src/components/common/Portal.tsx
 'use client';
 import { ReactNode, useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';

--- a/app/components/login/Portal.tsx
+++ b/app/components/login/Portal.tsx
@@ -1,0 +1,20 @@
+// src/components/common/Portal.tsx
+'use client';
+import { ReactNode, useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+interface PortalProps {
+  children: ReactNode;
+}
+
+export default function Portal({ children }: PortalProps) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    return () => setMounted(false);
+  }, []);
+
+  if (!mounted) return null;
+  return createPortal(children, document.body);
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import localFont from 'next/font/local';
 import { SessionProvider } from 'next-auth/react';
 
 import GlobalLoadingProvider from './components/loading/GlobalLoadingProvider';
+import LoginRedirectModal from './components/login/LoginRedirectModal';
 
 // 폰트 설정
 const pretendard = localFont({
@@ -64,6 +65,7 @@ export default function RootLayout({
       <body>
         <SessionProvider>{children}</SessionProvider>
         <GlobalLoadingProvider />
+        <LoginRedirectModal />
       </body>
     </html>
   );

--- a/app/simulator/SimulatorPage.tsx
+++ b/app/simulator/SimulatorPage.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useEffect, useMemo, useRef, useState } from 'react';
 import { Canvas } from '@react-three/fiber';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { useSession } from 'next-auth/react';
 
 import { Button } from '@/components/ui/button';
 
@@ -10,6 +11,7 @@ import { fetchFurnitureByPlacementType } from '@/apis/furnitures';
 import { getRoomById } from '@/apis/rooms';
 import { useFurnitureStore } from '@/stores/useFurnitureStore';
 import { useLoadingStore } from '@/stores/useLoadingStore';
+import { useLoginRedirectModalStore } from '@/stores/useLoginRedirectModalStore';
 import { useRoomSizeStore } from '@/stores/useRoomSizeStore';
 
 import CaptureCanvas from './components/capture/CaptureCanvas';
@@ -28,6 +30,8 @@ interface SimulatorPageProps {
   roomId?: string;
 }
 export default function SimulatorPage({ mode, roomId }: SimulatorPageProps) {
+  const session = useSession();
+  const { openModal } = useLoginRedirectModalStore();
   const { setLoading } = useLoadingStore();
   const [canvasCreated, setCanvasCreated] = useState(false);
   const [sceneLoaded, setSceneLoaded] = useState(false);
@@ -70,6 +74,10 @@ export default function SimulatorPage({ mode, roomId }: SimulatorPageProps) {
   const cameraDistance = Math.max(roomWidth, roomHeight) * 1.4;
 
   const handleSaveClick = () => {
+    if (!session.data) {
+      openModal();
+      return;
+    }
     if (mode === 'create') {
       setIsSaveModalOpen(true); // 저장 모달 띄우기
       // } else {

--- a/auth.ts
+++ b/auth.ts
@@ -1,4 +1,3 @@
-// auth.ts
 import { PrismaAdapter } from '@auth/prisma-adapter';
 import NextAuth from 'next-auth';
 import Google from 'next-auth/providers/google';

--- a/stores/useLoginRedirectModalStore.ts
+++ b/stores/useLoginRedirectModalStore.ts
@@ -1,0 +1,16 @@
+// src/store/useLoginRedirectModalStore.ts
+import { create } from 'zustand';
+
+interface LoginRedirectModalState {
+  open: boolean;
+  openModal: () => void;
+  closeModal: () => void;
+}
+
+export const useLoginRedirectModalStore = create<LoginRedirectModalState>(
+  (set) => ({
+    open: false,
+    openModal: () => set({ open: true }),
+    closeModal: () => set({ open: false }),
+  }),
+);

--- a/stores/useLoginRedirectModalStore.ts
+++ b/stores/useLoginRedirectModalStore.ts
@@ -1,4 +1,3 @@
-// src/store/useLoginRedirectModalStore.ts
 import { create } from 'zustand';
 
 interface LoginRedirectModalState {


### PR DESCRIPTION
## 🛠️ 작업 내용
로그인 분기 처리
- 로그인 모달 ( 훅만 불러와서 사용하도록(openModal), esc로도 닫히도록, 바깥클릭 닫히도록, body에 렌더링)
- 시뮬레이터 저장하기 버튼에 로그인 분기처리 

## 📌 PR 타입 (복수 선택 가능)
- [x] 기능 추가

## 📸 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/42d322b5-c51c-47ba-8627-72d9f08d43cf)

## 🔍 리뷰 요구사항(선택)
-  로그인 모달은 const { openModal } = useLoginRedirectModalStore(); 만 불러와서 처리하고 싶은 곳에 onClick={openModal()} 이런식으로 넣어주시면 됩니다.
- 미들웨어 처리는 list페이지 경로 최종적으로 정해지면 할게요.( ex)list -> rooms/[id] )
