### PR TITLE
R2B-65-MinorFunctionalUpdate

### DIFF
--- a/app/(anon)/login/page.tsx
+++ b/app/(anon)/login/page.tsx
@@ -54,7 +54,11 @@ export default function LoginPage() {
           <button
             className='flex items-center gap-3 px-6 py-3 border border-[#FEE500] rounded-xl bg-[#FEE500] hover:bg-[#e6c800] transition text-[#3C1E1E] font-medium'
             type='button'
-            onClick={() => signIn('kakao')}
+            onClick={() =>
+              alert(
+                '카카오 로그인은 현재 준비 중입니다. google로 로그인 해주세요',
+              )
+            }
           >
             <span className='bg-white rounded-full w-7 h-7 flex items-center justify-center'>
               <Image
@@ -70,7 +74,11 @@ export default function LoginPage() {
           <button
             className='flex items-center gap-3 px-6 py-3 border border-[#03C75A] rounded-xl bg-[#03C75A] hover:bg-[#02b152] transition text-white font-medium'
             type='button'
-            onClick={() => signIn('naver')}
+            onClick={() =>
+              alert(
+                '네이버 로그인은 현재 준비 중입니다. google로 로그인 해주세요',
+              )
+            }
           >
             <span className='bg-white rounded w-7 h-7 flex items-center justify-center'>
               <span className='text-[#03C75A] font-extrabold text-lg'>N</span>

--- a/app/simulator/SimulatorPage.tsx
+++ b/app/simulator/SimulatorPage.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useEffect, useMemo, useRef, useState } from 'react';
 import { Canvas } from '@react-three/fiber';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { useSession } from 'next-auth/react';
 
 import { Button } from '@/components/ui/button';
 
@@ -41,6 +42,7 @@ export default function SimulatorPage({ mode, roomId }: SimulatorPageProps) {
   const [isSaveModalOpen, setIsSaveModalOpen] = useState(false);
   const captureCanvasRef = useRef<HTMLCanvasElement>(null);
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+  const session = useSession();
   const [roomCameraPosition, setRoomCameraPosition] = useState<
     [number, number, number] | undefined
   >(undefined);
@@ -77,6 +79,10 @@ export default function SimulatorPage({ mode, roomId }: SimulatorPageProps) {
   const cameraDistance = Math.max(roomWidth, roomHeight) * 1.4;
 
   const handleSaveClick = () => {
+    if (!session.data) {
+      openModal();
+      return;
+    }
     useFurnitureStore.getState().selectFurniture(null);
 
     if (furnitures.length === 0) {

--- a/app/simulator/components/sidebar/FurnitureSidebar.tsx
+++ b/app/simulator/components/sidebar/FurnitureSidebar.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
 
 import type { Furnitures } from '@/app/types/furniture';
 
@@ -61,13 +63,18 @@ export default function FurnitureSidebar({
       `}
     >
       {/* 로고 */}
-      <div className='mb-3'>
-        <img
+      <Link
+        href='/'
+        className='mb-3 w-[80px] h-[33px] flex items-center justify-center'
+      >
+        <Image
           src='/assets/icons/roomtobe-logo.svg'
+          width={80}
+          height={33}
           alt='RoomToBe Logo'
           className='w-20 h-auto ml-1'
         />
-      </div>
+      </Link>
 
       {!expandedCategory && (
         <>

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,19 @@
-export { auth as middleware } from '@/auth';
+// middleware.ts
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+import { auth } from '@/auth';
+
+export async function middleware(req: NextRequest) {
+  const session = await auth();
+
+  if (!session?.user) {
+    return NextResponse.redirect(new URL('/', req.url));
+  }
+
+  return NextResponse.next();
+}
 
 export const config = {
-  matcher: ['/protected/:path*'], // TODO:인증 필요한 경로 설정
+  matcher: ['/rooms/:id/edit', '/rooms/:id', '/list/:path*'],
 };


### PR DESCRIPTION
## 🛠️ 작업 내용
- [x]  list 페이지 진입 불가 상황
- [x]  middleware 설정
    - [x]  유저 아이디가 없을 때 list 페이지로 이동 시, 로그인 페이지로 리다이렉트 처리 필요
    - [x]  /rooms/[id]/edit , /rooms/[id] 
- [x]  login 페이지 개발 진행 혹은 개발중입니다 알림
- [x]  Simulator 페이지 로고 누르면 Home으로
- [x]  Simulator 페이지 비회원이 저장하기 눌렀을 때 로그인 페이지로 이동( 현재 alert )

## 📌 PR 타입 (복수 선택 가능)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성 / 환경변수 / 빌드 관련 업데이트

## 🔍 리뷰 요구사항(선택)
- 편의성 관련 건의(후순위): 로그인 하지 않고 방생성(가구 배치완료) -> 저장하기 -> 로그인하세요 -> 가구정보 날라감. -> 처음부터 다시 가구배치. 만약 로그인 전 만들어 놓은 가구 배치가 있다면 로그인 후 로그인 전에 만들어놨던 가구 배치를 불러와서 저장 할 수 있도록 하면 좋을듯 합니다. 즉 임시저장기능 1개(로컬)